### PR TITLE
Fix temporizzazione tra i simulatori e kafka

### DIFF
--- a/PythonSensorsSimulator/main.py
+++ b/PythonSensorsSimulator/main.py
@@ -4,9 +4,6 @@ import os
 from Model.BuilderSimulatorExecutor import BuilderSimulatorExecutor
 from Model.Writers.KafkaWriter import KafkaWriter
 
-time.sleep(5) # Per far si che Kafka sia già UP all'invio dei messaggi.
-# TODO: da automatizzare come processo.
-
 KAFKA_HOST = os.environ.get("KAFKA_HOST", "localhost")
 KAFKA_PORT = os.environ.get("KAFKA_PORT", "9092")
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,6 +37,11 @@ services:
       KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
     depends_on:
       - zoo
+    healthcheck:
+      test: [ "CMD", "kafka-topics", "--bootstrap-server", "localhost:9092", "--list"]
+      interval: 1s
+      timeout: 2s
+      retries: 10
 
   simulators:
     build:
@@ -47,4 +52,5 @@ services:
       KAFKA_HOST: "kafka"
       KAFKA_PORT: "9092"
     depends_on:
-      - kafka
+      kafka:
+        condition: service_healthy


### PR DESCRIPTION
Controllo di healthcheck su kafka tramite docker compose per sincronizzare i simulatori senza attesa attiva

close #16 
close #12 